### PR TITLE
Fix/html replacer换行和无属性时报错

### DIFF
--- a/src/replacer/html.ts
+++ b/src/replacer/html.ts
@@ -36,8 +36,9 @@ export const createHTMLReplacer = (config: ReplacerConfig) => {
         // @ts-ignore
         const astNode = node[0].nodePath.node
 
-        // @ts-ignore 标签属性遍历
-        astNode.content?.attributes.forEach(i => {
+        // @ts-ignore 标签属性遍历，当标签元素不包含属性的时候，astNode.content.attributes为undefined，需要使用 ?. 判断一下forEach
+        astNode.content?.attributes?.forEach(i => {
+            if(i.key.content === '\r') return; // 过滤掉换行符
             const attrName = i.key.content
             const value = i.value.content
             const newValue = config.attrReplacer(attrName.toString(), value)


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix errors in the HTML replacer when elements have no attributes and enhance the replacer to ignore carriage return characters in attribute keys.

Bug Fixes:
- Fix an error when processing HTML elements without attributes by adding a nullish coalescing operator to safely access attributes.

Enhancements:
- Filter out carriage return characters from HTML attribute keys during processing.

<!-- Generated by sourcery-ai[bot]: end summary -->